### PR TITLE
match ; as a comment

### DIFF
--- a/syntaxes/Gitconfig.tmLanguage
+++ b/syntaxes/Gitconfig.tmLanguage
@@ -14,7 +14,7 @@
 			<key>comment</key>
 			<string>Comments</string>
 			<key>match</key>
-			<string>#.*</string>
+			<string>(#|;).*</string>
 			<key>name</key>
 			<string>comment.gitconfig</string>
 		</dict>


### PR DESCRIPTION
From [the documentation](https://git-scm.com/docs/git-config#_syntax):

> Syntax
   The `#` and `;` characters begin comments to the end of line
